### PR TITLE
Libs can be found by specifying include directory

### DIFF
--- a/FindICU.cmake
+++ b/FindICU.cmake
@@ -113,6 +113,7 @@ foreach(_icu_component ${ICU_FIND_COMPONENTS})
         _icu_lib
         NAMES ${IcuComponents_${_icu_component}}
         DOC "Libraries for ICU"
+        PATHS "${ICU_INCLUDE_DIR}/../lib"
     )
 
     string(TOUPPER "${_icu_component}" _icu_upper_component)


### PR DESCRIPTION
It's now possible to do it on Windows. I guess.
